### PR TITLE
Replaced COMPILE_TIME_ASSERT() with static_assert()

### DIFF
--- a/src/DwarfInstructions.hpp
+++ b/src/DwarfInstructions.hpp
@@ -29,6 +29,7 @@
 #ifndef __DWARF_INSTRUCTIONS_HPP__
 #define __DWARF_INSTRUCTIONS_HPP__
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -917,7 +918,8 @@ typename A::pint_t DwarfInstructions<A,R>::evaluateExpression(pint_t expression,
 template <typename A, typename R>
 int DwarfInstructions<A,R>::lastRestoreReg(const Registers_x86_64&) 
 {
-	COMPILE_TIME_ASSERT( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)DW_X86_64_RET_ADDR );
+	static_assert( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)DW_X86_64_RET_ADDR,
+	 "(int)CFI_Parser<A>::kMaxRegisterNumber MUST be > (int)DW_X86_64_RET_ADDR" );
 	return DW_X86_64_RET_ADDR; 
 }
 
@@ -1312,7 +1314,8 @@ compact_unwind_encoding_t DwarfInstructions<A,R>::createCompactEncodingFromProlo
 template <typename A, typename R>
 int DwarfInstructions<A,R>::lastRestoreReg(const Registers_x86&) 
 {
-	COMPILE_TIME_ASSERT( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)DW_X86_RET_ADDR );
+	static_assert( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)DW_X86_RET_ADDR,
+	"(int)CFI_Parser<A>::kMaxRegisterNumber MUST be > (int)DW_X86_RET_ADDR" );
 	return DW_X86_RET_ADDR; 
 }
 
@@ -1688,7 +1691,8 @@ compact_unwind_encoding_t DwarfInstructions<A,R>::createCompactEncodingFromProlo
 template <typename A, typename R>
 int DwarfInstructions<A,R>::lastRestoreReg(const Registers_ppc&) 
 {
-	COMPILE_TIME_ASSERT( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)UNW_PPC_SPEFSCR );
+	static_assert( (int)CFI_Parser<A>::kMaxRegisterNumber > (int)UNW_PPC_SPEFSCR,
+	"(int)CFI_Parser<A>::kMaxRegisterNumber MUST be > (int)UNW_PPC_SPEFSCR" );
 	return UNW_PPC_SPEFSCR; 
 }
 

--- a/src/InternalMacros.h
+++ b/src/InternalMacros.h
@@ -21,7 +21,7 @@
  *
  * @APPLE_LICENSE_HEADER_END@
  */
- 
+
 
 
 #ifndef INTERNAL_MACROS_H
@@ -45,15 +45,12 @@ extern "C" {
 struct v128 { unsigned int vec[4]; };
 
 
-#define EXPORT __attribute__((visibility("default"))) 
+#define EXPORT __attribute__((visibility("default")))
 
-#define COMPILE_TIME_ASSERT( expr )    \
-		extern int compile_time_assert_failed[ ( expr ) ? 1 : -1 ] __attribute__( ( unused ) );
-
-#define ABORT(msg) __assert_rtn(__func__, __FILE__, __LINE__, msg) 
+#define ABORT(msg) __assert_rtn(__func__, __FILE__, __LINE__, msg)
 
 #if NDEBUG
-	#define DEBUG_MESSAGE(msg, ...)  
+	#define DEBUG_MESSAGE(msg, ...)
 	#define DEBUG_PRINT_API(msg, ...)
 	#define DEBUG_PRINT_UNWINDING_TEST 0
 	#define DEBUG_PRINT_UNWINDING(msg, ...)
@@ -93,7 +90,7 @@ struct v128 { unsigned int vec[4]; };
 
 #define NOT_HERE_BEFORE_10_6(sym) \
 	extern const char sym##_tmp4 __asm("$ld$hide$os10.4$_" #sym ); __attribute__((visibility("default"))) const char sym##_tmp4 = 0; \
-	extern const char sym##_tmp5 __asm("$ld$hide$os10.5$_" #sym ); __attribute__((visibility("default"))) const char sym##_tmp5 = 0; 
+	extern const char sym##_tmp5 __asm("$ld$hide$os10.5$_" #sym ); __attribute__((visibility("default"))) const char sym##_tmp5 = 0;
 #define NEVER_HERE(sym) \
 	extern const char sym##_tmp4 __asm("$ld$hide$os10.4$_" #sym ); __attribute__((visibility("default"))) const char sym##_tmp4 = 0; \
 	extern const char sym##_tmp5 __asm("$ld$hide$os10.5$_" #sym ); __attribute__((visibility("default"))) const char sym##_tmp5 = 0; \

--- a/src/Registers.hpp
+++ b/src/Registers.hpp
@@ -29,6 +29,7 @@
 #ifndef __REGISTERS_HPP__
 #define __REGISTERS_HPP__
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -106,7 +107,8 @@ private:
 
 inline Registers_x86::Registers_x86(const void* registers)
 {
-	COMPILE_TIME_ASSERT( sizeof(Registers_x86) < sizeof(unw_context_t) );
+	static_assert( sizeof(Registers_x86) < sizeof(unw_context_t),
+	"sizeof(Registers_x86) MUST be < sizeof(unw_context_t)" );
 	fRegisters = *((GPRs*)registers); 
 }
 
@@ -310,7 +312,8 @@ private:
 
 inline Registers_x86_64::Registers_x86_64(const void* registers)
 {
-	COMPILE_TIME_ASSERT( sizeof(Registers_x86_64) < sizeof(unw_context_t) );
+	static_assert( sizeof(Registers_x86_64) < sizeof(unw_context_t),
+	"sizeof(Registers_x86_64) MUST be < sizeof(unw_context_t)" );
 	fRegisters = *((GPRs*)registers); 
 }
 
@@ -588,7 +591,8 @@ private:
 
 inline Registers_ppc::Registers_ppc(const void* registers) 
 {
-	COMPILE_TIME_ASSERT( sizeof(Registers_ppc) < sizeof(unw_context_t) );
+	static_assert( sizeof(Registers_ppc) < sizeof(unw_context_t) ,
+	              "sizeof(Registers_ppc) MUST be < sizeof(unw_context_t)");
 	fRegisters = *((ppc_thread_state_t*)registers); 
 	fFloatRegisters = *((ppc_float_state_t*)((char*)registers+160));
 	memcpy(fVectorRegisters, ((char*)registers+424), sizeof(fVectorRegisters));

--- a/src/UnwindCursor.hpp
+++ b/src/UnwindCursor.hpp
@@ -29,6 +29,7 @@
 #ifndef __UNWINDCURSOR_HPP__
 #define __UNWINDCURSOR_HPP__
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -405,7 +406,8 @@ template <typename A, typename R>
 UnwindCursor<A,R>::UnwindCursor(unw_context_t* context, A& as)
   : fUnwindInfoMissing(false), fIsSignalFrame(false), fForceDwarf(false), fRegisters(context), fAddressSpace(as)
 {
-	COMPILE_TIME_ASSERT( sizeof(UnwindCursor<A,R>) < sizeof(unw_cursor_t) );
+	static_assert( sizeof(UnwindCursor<A,R>) < sizeof(unw_cursor_t),
+	"sizeof(UnwindCursor<A,R>) MUST be < sizeof(unw_cursor_t)" );
 
 	bzero(&fInfo, sizeof(fInfo));
 }


### PR DESCRIPTION
@Keno this is the pull-request version of #6.

The former is a version of the latter, but the latter is part of the C and C++
standards, and so is supported on all compliant compilers.